### PR TITLE
fix(nutrient): use folder-mode invocation instead of per-document subprocess

### DIFF
--- a/src/pdf_parser_nutrient.py
+++ b/src/pdf_parser_nutrient.py
@@ -1,3 +1,11 @@
+"""PDF parser using Nutrient's pdf-to-markdown CLI.
+
+Invokes the CLI in folder mode (one subprocess per directory) when given a
+directory, and in single-file mode when given one PDF. Requires the
+``pdf-to-markdown`` binary on PATH — install with:
+``npm install -g @pspdfkit/pdf-to-markdown``.
+"""
+
 import shutil
 import subprocess
 from pathlib import Path
@@ -11,6 +19,12 @@ if _pdf_to_md_bin is None:
 
 
 def to_markdown(doc_paths, input_path, output_dir):
+    """Convert PDF(s) to Markdown via the pdf-to-markdown CLI.
+
+    When ``input_path`` is a directory, the CLI is invoked once in folder
+    mode for the whole corpus. When it is a single file, output is written
+    to a named ``.md`` file inside ``output_dir``.
+    """
     input_path = Path(input_path)
     output_dir = Path(output_dir)
 

--- a/src/pdf_parser_nutrient.py
+++ b/src/pdf_parser_nutrient.py
@@ -1,22 +1,25 @@
-import os
 import shutil
 import subprocess
+from pathlib import Path
+
+_pdf_to_md_bin = shutil.which("pdf-to-markdown")
+if _pdf_to_md_bin is None:
+    raise ImportError(
+        "pdf-to-markdown not found on PATH. "
+        "Install it with: npm install -g @pspdfkit/pdf-to-markdown"
+    )
 
 
 def to_markdown(doc_paths, input_path, output_dir):
-    pdf_to_md_bin = shutil.which("pdf-to-markdown")
+    input_path = Path(input_path)
+    output_dir = Path(output_dir)
 
-    for doc_path in doc_paths:
-        base_name = os.path.splitext(os.path.basename(doc_path))[0]
-        output_file = os.path.join(output_dir, f"{base_name}.md")
+    if input_path.is_file():
+        output = output_dir / (input_path.stem + ".md")
+    else:
+        output = output_dir
 
-        if pdf_to_md_bin:
-            subprocess.run(
-                [pdf_to_md_bin, str(doc_path), output_file],
-                check=True,
-            )
-        else:
-            subprocess.run(
-                ["npx", "@pspdfkit/pdf-to-markdown", str(doc_path), output_file],
-                check=True,
-            )
+    subprocess.run(
+        [_pdf_to_md_bin, str(input_path), str(output)],
+        check=True,
+    )


### PR DESCRIPTION
While reviewing the benchmark harness, we noticed a mistake in the
way Nutrient was integrated. It was the only parser spawning a new
OS process for every PDF. With 200 documents this meant:

- 200 `subprocess.run()` calls, each forking a new OS process
- 200 `pdf-to-markdown` binary loads instead of 1
- 200 redundant `os.path.basename` / `os.path.splitext` / `os.path.join`
- 200 `npx` invocations when the binary isn't on PATH, each loading
  Node.js and resolving the npm package, even including an initial
  download cost

In the best case (binary on PATH, no npx), this added ~24s of pure
process-spawn overhead to the benchmark, none of which reflects
actual conversion performance.

No other engine pays those overheads. OpenDataLoader also passes the
folder in one call.

The `pdf-to-markdown` CLI supports folder mode (dir in, dir out). This
change uses it: one subprocess for the whole corpus. The `npx` fallback
is also removed — the binary is resolved once at import, matching how
other engines fail early when their dependency is missing.

Numbers from a run to illustrate the impact:

### Benchmark (200 documents, Debian amd64, AMD EPYC 9454)

| Engine           | NID    | TEDS   | MHS    | Total   | Per doc  |
|------------------|--------|--------|--------|---------|----------|
| opendataloader   | 0.9023 | 0.4887 | 0.7395 |  3.33s  | 0.017s   |
| nutrient (fixed) | 0.9236 | 0.6616 | 0.8109 |  1.68s  | 0.008s   |
| nutrient (broken)| 0.9236 | 0.6616 | 0.8109 | 25.63s  | 0.128s   |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Now surfaces a missing PDF-to-markdown converter earlier at startup for faster failure detection.

* **Chores**
  * Improved PDF conversion efficiency by consolidating processing into a single run.
  * When converting a single file, produces one markdown output named after the source; when given a directory, treats the output location as a folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->