### PR TITLE
chore(deps): bump python-multipart constraint to >=0.0.31 (security)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,5 @@ testpaths = ["tests"]
 [tool.uv]
 constraint-dependencies = [
     "cryptography>=46.0.7",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.31",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.31" },
 ]
 
 [[package]]
@@ -2286,11 +2286,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.27"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Objective
Close **4 open Dependabot alerts** on `python-multipart` that were sitting unremediated with **no PR** (Dependabot is not opening security PRs on this repo).

| GHSA | Severity | Vulnerable | First patched |
|---|---|---|---|
| GHSA-5rvq-cxj2-64vf | **high** | `< 0.0.30` | 0.0.30 |
| GHSA-6jv3-5f52-599m | low | `< 0.0.30` | 0.0.30 |
| GHSA-vffw-93wf-4j4q | low | `< 0.0.30` | 0.0.30 |
| GHSA-v9pg-7xvm-68hf | low | `< 0.0.31` | 0.0.31 |

## Approach
Raise the uv constraint `python-multipart >=0.0.26` → `>=0.0.31` and re-lock. `uv lock` resolves python-multipart **0.0.27 → 0.0.32** (≥ every patched version, so all 4 close and the floor can't regress). `python-multipart` is pulled only transitively via the `opendataloader-pdf[hybrid]` engine extra (fastapi/uvicorn); bench source never imports it.

## Evidence
- **uv lock**: single change — `python-multipart 0.0.27 → 0.0.32`, no other package churn (168 resolved, only this one updated).
- **Unit tests**: `31 passed` (apted/rapidfuzz/bs4/lxml; multipart is on no test path).
- **Independent side-effect review**: 0.0.27→0.0.32 is a security/bugfix line with no public API changes; blast radius ~zero for a benchmarking tool that doesn't handle untrusted multipart input. Verdict: **safe to merge**.

## Notes
- Manifest + lock only; no source changes. Human merges — not auto-merged.
- The security-triage signal check / meta review will run against this PR (head branch `security/…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)