### PR TITLE
fix: resolve reference.json independently of the GT markdown dir

### DIFF
--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -28,6 +28,7 @@ from evaluator_table import evaluate_table
 
 
 DEFAULT_GT_DIR = "ground-truth/markdown"
+DEFAULT_REFERENCE_PATH = "ground-truth/reference.json"
 DEFAULT_PREDICTION_ROOT = "prediction"
 DEFAULT_OUTPUT_FILENAME = "evaluation.json"
 

--- a/src/run.py
+++ b/src/run.py
@@ -14,6 +14,7 @@ from evaluator import (
     DEFAULT_GT_DIR,
     DEFAULT_OUTPUT_FILENAME,
     DEFAULT_PREDICTION_ROOT,
+    DEFAULT_REFERENCE_PATH,
     run as evaluate_run,
 )
 from engine_registry import ENGINES
@@ -27,6 +28,16 @@ def _resolve_path(value: str, project_root: Path) -> Path:
 
     path = Path(value)
     return path if path.is_absolute() else project_root / path
+
+
+def resolve_reference_path(args: argparse.Namespace, project_root: Path) -> Path:
+    """Resolve the ground-truth ``reference.json`` path.
+
+    Kept independent of ``--ground-truth-dir`` (which points at the GT *markdown*
+    directory) so that table-detection and triage evaluation always locate
+    reference.json instead of looking for it under the markdown subdirectory.
+    """
+    return _resolve_path(args.reference_path, project_root)
 
 
 def _select_engine(requested: Optional[str]) -> List[str]:
@@ -224,7 +235,7 @@ def run_pipeline(args: argparse.Namespace) -> Optional[dict]:
         eval_data = json.load(f)
 
     # Table detection evaluation
-    reference_path = ground_truth_dir / "reference.json"
+    reference_path = resolve_reference_path(args, project_root)
     if reference_path.exists():
         from evaluator_table_detection import evaluate_table_detection_batch
 
@@ -317,6 +328,12 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         "--ground-truth-dir",
         default=DEFAULT_GT_DIR,
         help="Directory that stores ground-truth markdown files.",
+    )
+    parser.add_argument(
+        "--reference-path",
+        default=DEFAULT_REFERENCE_PATH,
+        help="Path to ground-truth reference.json used for table-detection and "
+             "triage evaluation (defaults to ground-truth/reference.json).",
     )
     parser.add_argument(
         "--prediction-root",

--- a/tests/test_reference_path.py
+++ b/tests/test_reference_path.py
@@ -1,0 +1,57 @@
+"""Tests for reference.json path resolution.
+
+Regression: the harness resolved reference.json under ``ground-truth/markdown/``
+(the GT *markdown* dir) where the file does not exist, so ``run.py`` silently
+skipped table-detection (and triage) evaluation and the ``table_detection_f1``
+regression gate could never fire.
+"""
+import json
+from pathlib import Path
+
+import run
+from evaluator_table_detection import evaluate_table_detection_batch
+
+
+def test_default_reference_path_points_to_existing_file():
+    """The default reference path must resolve to the real reference.json."""
+    args = run._parse_args(["--engine", "opendataloader"])
+    project_root = Path(run.__file__).parent.parent
+    reference_path = run.resolve_reference_path(args, project_root)
+    assert reference_path.name == "reference.json"
+    assert reference_path.exists(), (
+        f"reference.json must resolve to an existing file, got {reference_path}"
+    )
+
+
+def test_reference_path_independent_of_ground_truth_dir_override():
+    """Overriding --ground-truth-dir must not move the reference.json path."""
+    args = run._parse_args(
+        ["--engine", "opendataloader", "--ground-truth-dir", "/some/other/gt"]
+    )
+    project_root = Path(run.__file__).parent.parent
+    reference_path = run.resolve_reference_path(args, project_root)
+    # Still anchored at the repo's ground-truth/reference.json, not /some/other/gt.
+    assert reference_path == project_root / "ground-truth" / "reference.json"
+
+
+def test_table_detection_f1_on_synthetic_corpus(tmp_path):
+    """Safety net: evaluate_table_detection_batch scores tables correctly given a
+    valid reference.json + markdown dir (independent of the path bug)."""
+    reference = {
+        "with_table.pdf": {"elements": [{"category": "Table", "page": 1}]},
+        "text_only.pdf": {"elements": [{"category": "Paragraph", "page": 1}]},
+    }
+    reference_path = tmp_path / "reference.json"
+    reference_path.write_text(json.dumps(reference), encoding="utf-8")
+
+    markdown_dir = tmp_path / "markdown"
+    markdown_dir.mkdir()
+    (markdown_dir / "with_table.md").write_text(
+        "| h1 | h2 |\n| --- | --- |\n| 1 | 2 |\n", encoding="utf-8"
+    )
+    (markdown_dir / "text_only.md").write_text("Just a paragraph.\n", encoding="utf-8")
+
+    metrics = evaluate_table_detection_batch(reference_path, markdown_dir).to_dict()
+    assert metrics["tp"] == 1 and metrics["tn"] == 1
+    assert metrics["fp"] == 0 and metrics["fn"] == 0
+    assert metrics["f1"] == 1.0


### PR DESCRIPTION
Fixes https://github.com/opendataloader-project/opendataloader-bench/issues/30

## Problem

`run.py --check-regression` reports `Table Detection: F1: N/A`. The table-detection block resolves `reference.json` under `ground-truth/markdown/` (`DEFAULT_GT_DIR`), where it does not exist — the actual file is `ground-truth/reference.json`. So `if reference_path.exists()` is always False, the block is skipped, and the `table_detection_f1` regression gate can never fire.

## Fix

Add a `DEFAULT_REFERENCE_PATH = "ground-truth/reference.json"` constant and a `--reference-path` argument resolved independently of `--ground-truth-dir` (which points at the GT *markdown* directory). `reference_path` now resolves to the real file, so the table-detection evaluation runs.

## Tests

`tests/test_reference_path.py`:
- the default reference path resolves to an existing `reference.json`;
- it stays anchored at `ground-truth/reference.json` even when `--ground-truth-dir` is overridden;
- a synthetic-corpus safety net for `evaluate_table_detection_batch` (tp/tn/F1).

Full suite: 34 passed.

## Verified

With the fix, evaluating the repository's committed prediction outputs, `run.py --check-regression` now populates Table-Detection F1 where it printed N/A before: **0.62** for the deterministic `opendataloader` engine (P 0.60 / R 0.64; tp=27 fp=18 fn=15 tn=140 — the one the CI benchmark uses) and 0.97 for `opendataloader-hybrid` (tp=42 fp=3 fn=0 tn=155). So the `table_detection_f1: 0.55` gate is meaningful again.

Note: the `triage_recall` / `triage_fn_max` gates stay inert for an independent reason (no engine emits `triage.json`); tracked separately in https://github.com/opendataloader-project/opendataloader-bench/issues/29, out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to explicitly select the reference data file used during evaluation.
  * Reference data is now resolved independently from the markdown ground-truth directory.

* **Bug Fixes**
  * Prevented ground-truth directory overrides from unintentionally changing the reference data location.

* **Tests**
  * Added coverage for default path resolution, custom directory handling, and table-detection evaluation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->